### PR TITLE
Fix login flow behavior

### DIFF
--- a/app/src/main/java/com/example/mona/facebookoffline/auth/SplashActivity.java
+++ b/app/src/main/java/com/example/mona/facebookoffline/auth/SplashActivity.java
@@ -7,6 +7,7 @@ import android.widget.Toast;
 
 import com.example.mona.facebookoffline.MainActivity;
 import com.example.mona.facebookoffline.R;
+import com.facebook.AccessToken;
 import com.facebook.FacebookException;
 import com.facebook.login.LoginResult;
 
@@ -22,17 +23,29 @@ public class SplashActivity extends Activity implements LoginFragment.LoginListe
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_splash);
+        if (isLoggedIn()) {
+            launchMainActivityAndFinish();
+        }
     }
 
     @Override
     public void onSuccess(LoginResult loginResult) {
-        // Launch MainActivity
-        startActivity(new Intent(this, MainActivity.class));
+        launchMainActivityAndFinish();
     }
 
     @Override
     public void onError(FacebookException error) {
         // Display a toast to the user
         Toast.makeText(this, R.string.unable_to_login, Toast.LENGTH_SHORT).show();
+    }
+
+    private boolean isLoggedIn() {
+        // TODO(mona): Is a non-null token enough to say it's valid? Unsure from the docs
+        return AccessToken.getCurrentAccessToken() != null;
+    }
+
+    private void launchMainActivityAndFinish() {
+        startActivity(new Intent(this, MainActivity.class));
+        finish();
     }
 }

--- a/app/src/main/java/com/example/mona/facebookoffline/auth/SplashActivity.java
+++ b/app/src/main/java/com/example/mona/facebookoffline/auth/SplashActivity.java
@@ -22,9 +22,11 @@ public class SplashActivity extends Activity implements LoginFragment.LoginListe
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_splash);
+
         if (isLoggedIn()) {
             launchMainActivityAndFinish();
+        } else {
+            setContentView(R.layout.activity_splash);
         }
     }
 


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/118676497

Fixes:
1) Back button behavior from MainActivity
2) Skips SplashActivity if already logged in

I'm worried that the `isLoggedIn()` method in `SplashActivity` is inaccurate, adding a [new PT](https://www.pivotaltracker.com/story/show/118701925) for investigating/fixing this issue.

@wesdotcool 
